### PR TITLE
Add QA automation scripts for validation, triage, and consensus

### DIFF
--- a/qa/dawid_skene.py
+++ b/qa/dawid_skene.py
@@ -1,0 +1,157 @@
+"""Minimal Dawid–Skene implementation for reviewer consensus (stage 4).
+
+The algorithm models each reviewer with a confusion matrix and infers the
+latent "true" label for every item.  We focus on the PASS/FIX/REJECT triad, but
+any discrete label space will work.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, MutableMapping, Tuple
+
+
+Label = str
+ReviewerID = str
+ItemID = str
+
+DEFAULT_LABELS: Tuple[Label, ...] = ("PASS", "FIX", "REJECT")
+SMOOTHING = 1e-3
+MAX_ITERATIONS = 50
+EPS = 1e-6
+
+
+@dataclass
+class Review:
+    item_id: ItemID
+    reviewer_id: ReviewerID
+    label: Label
+
+
+@dataclass
+class ConsensusResult:
+    item_id: ItemID
+    label: Label
+    posterior: Dict[Label, float]
+    confidence: float
+    needs_sme: bool
+
+
+@dataclass
+class DawidSkeneModel:
+    priors: Dict[Label, float]
+    confusion_matrices: Dict[ReviewerID, Dict[Label, Dict[Label, float]]]
+
+
+ROUTING_THRESHOLDS = {
+    "PASS": 0.80,
+    "FIX": 0.70,
+    "REJECT": 0.70,
+}
+
+
+def _normalize(dist: MutableMapping[Label, float]) -> None:
+    total = sum(dist.values())
+    if total <= 0:
+        size = len(dist)
+        for key in dist:
+            dist[key] = 1.0 / size
+        return
+    inv_total = 1.0 / total
+    for key in dist:
+        dist[key] *= inv_total
+
+
+def _initialize_priors(labels: Iterable[Label]) -> Dict[Label, float]:
+    labels = list(labels)
+    size = len(labels)
+    return {label: 1.0 / size for label in labels}
+
+
+def _initialize_confusion(reviewers: Iterable[ReviewerID], labels: Iterable[Label]) -> Dict[ReviewerID, Dict[Label, Dict[Label, float]]]:
+    labels = list(labels)
+    identity = {l: {obs: (1.0 if obs == l else SMOOTHING) for obs in labels} for l in labels}
+    for row in identity.values():
+        _normalize(row)
+    return {reviewer: {l: row.copy() for l, row in identity.items()} for reviewer in reviewers}
+
+
+def run_dawid_skene(reviews: Iterable[Review], labels: Iterable[Label] = DEFAULT_LABELS) -> Tuple[List[ConsensusResult], DawidSkeneModel]:
+    reviews = list(reviews)
+    if not reviews:
+        return [], DawidSkeneModel({}, {})
+
+    labels = tuple(labels)
+    items = {review.item_id for review in reviews}
+    reviewers = {review.reviewer_id for review in reviews}
+
+    priors = _initialize_priors(labels)
+    confusion = _initialize_confusion(reviewers, labels)
+
+    # Posterior per item for each iteration.
+    posteriors: Dict[ItemID, Dict[Label, float]] = {item: {label: 1.0 / len(labels) for label in labels} for item in items}
+
+    for _ in range(MAX_ITERATIONS):
+        # E-step: compute posteriors for each item.
+        new_posteriors: Dict[ItemID, Dict[Label, float]] = {}
+        for item in items:
+            probs = {label: priors[label] for label in labels}
+            for review in filter(lambda r, item=item: r.item_id == item, reviews):
+                reviewer_matrix = confusion[review.reviewer_id]
+                for label in labels:
+                    probs[label] *= reviewer_matrix[label].get(review.label, SMOOTHING)
+            _normalize(probs)
+            new_posteriors[item] = probs
+
+        delta = max(
+            abs(new_posteriors[item][label] - posteriors[item][label])
+            for item in items
+            for label in labels
+        )
+        posteriors = new_posteriors
+
+        if delta < EPS:
+            break
+
+        # M-step: update priors and confusion matrices.
+        priors = {label: 0.0 for label in labels}
+        for probs in posteriors.values():
+            for label, prob in probs.items():
+                priors[label] += prob
+        _normalize(priors)
+
+        for reviewer in reviewers:
+            counts = {label: {obs: SMOOTHING for obs in labels} for label in labels}
+            for review in filter(lambda r, reviewer=reviewer: r.reviewer_id == reviewer, reviews):
+                probs = posteriors[review.item_id]
+                for label in labels:
+                    counts[label][review.label] += probs[label]
+            for label in labels:
+                _normalize(counts[label])
+            confusion[reviewer] = counts
+
+    results: List[ConsensusResult] = []
+    for item, probs in posteriors.items():
+        label = max(probs.items(), key=lambda kv: kv[1])[0]
+        confidence = probs[label]
+        threshold = ROUTING_THRESHOLDS.get(label, 1.0)
+        needs_sme = confidence < threshold
+        results.append(
+            ConsensusResult(
+                item_id=item,
+                label=label,
+                posterior=dict(probs),
+                confidence=confidence,
+                needs_sme=needs_sme,
+            )
+        )
+
+    model = DawidSkeneModel(priors=priors, confusion_matrices=confusion)
+    return results, model
+
+
+__all__ = [
+    "Review",
+    "ConsensusResult",
+    "DawidSkeneModel",
+    "run_dawid_skene",
+]

--- a/qa/llm_triage.py
+++ b/qa/llm_triage.py
@@ -1,0 +1,76 @@
+"""Light-weight LLM triage heuristics for QA stage 2.
+
+The real system uses an LLM prompt (see ``qa/llm-system-prompt``).  To keep the
+repository runnable without external dependencies, we approximate the behavior
+with a deterministic heuristic that checks whether salient phrases from the
+answer appear in the cited quotes.  The output mirrors the production shape:
+priority flag (``HIGH``/``LOW``) plus a short reason string.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+import re
+
+
+@dataclass
+class TriageResult:
+    priority: str
+    reason: str
+
+
+KEYWORD_RE = re.compile(r"[A-Za-z0-9%$,.]+")
+PRIORITY_HIGH = "HIGH"
+PRIORITY_LOW = "LOW"
+
+
+def _extract_keywords(answer: str) -> List[str]:
+    tokens = KEYWORD_RE.findall(answer or "")
+    keywords: List[str] = []
+    for token in tokens:
+        if token.isdigit() and len(token) == 1:
+            continue
+        if len(token) <= 3 and not re.search(r"\d", token):
+            continue
+        keywords.append(token.lower())
+    return keywords
+
+
+def _quotes_from_citations(citations: Iterable[Dict]) -> List[str]:
+    quotes: List[str] = []
+    for citation in citations or []:
+        quote = (citation or {}).get("quote")
+        if quote:
+            quotes.append(str(quote).lower())
+    return quotes
+
+
+def triage_submission(submission: Dict) -> TriageResult:
+    """Assign a triage priority to a submission based on quote coverage."""
+
+    answer = submission.get("answer", "") or ""
+    citations = submission.get("citations", []) or []
+    keywords = _extract_keywords(answer)
+    quotes = _quotes_from_citations(citations)
+
+    if not answer.strip():
+        return TriageResult(PRIORITY_HIGH, "blank answer")
+    if not quotes:
+        return TriageResult(PRIORITY_HIGH, "no supporting quotes provided")
+
+    missing: List[str] = []
+    concatenated = " \n ".join(quotes)
+    for keyword in keywords:
+        if keyword not in concatenated:
+            missing.append(keyword)
+        if len(missing) >= 3:
+            break
+
+    if missing:
+        reason = f"answer keywords missing from quotes: {', '.join(missing)}"
+        return TriageResult(PRIORITY_HIGH, reason)
+
+    return TriageResult(PRIORITY_LOW, "answer terms supported by quotes")
+
+
+__all__ = ["TriageResult", "triage_submission"]

--- a/qa/programmatic_validation.py
+++ b/qa/programmatic_validation.py
@@ -1,0 +1,151 @@
+"""Programmatic validation utilities for QA stage 1.
+
+This module exposes a small helper that checks basic structural
+requirements for a submission prior to human or LLM review.  The goal is to
+fail fast on obvious data quality problems (e.g., malformed citations or
+non-EDGAR links) so review capacity is not wasted.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+from urllib.parse import urlparse
+
+
+@dataclass
+class ValidationIssue:
+    """Represents a single validation issue detected during stage 1."""
+
+    field: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.field}: {self.message}"
+
+
+REQUIRED_TOP_LEVEL_FIELDS: Tuple[str, ...] = (
+    "prompt",
+    "answer",
+    "citations",
+    "metadata",
+)
+REQUIRED_METADATA_FIELDS: Tuple[str, ...] = ("category", "requires_calc")
+VALID_CATEGORIES = {"A", "B", "C", "C-Extended"}
+
+
+def _word_count(text: str) -> int:
+    return len(text.split())
+
+
+def _is_sec_domain(url: str) -> bool:
+    try:
+        hostname = urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    return hostname.endswith("sec.gov")
+
+
+def _ensure_iterable(value) -> Iterable:
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return value
+    return ()
+
+
+def validate_submission(submission: Dict) -> Tuple[bool, List[ValidationIssue]]:
+    """Validate a submission for stage 1 programmatic checks.
+
+    Parameters
+    ----------
+    submission:
+        Mapping representing a single QA submission.  The expected schema is
+        intentionally lean and mirrors the data bundle produced in the
+        deliverable stage.
+
+    Returns
+    -------
+    tuple
+        ``(is_valid, issues)`` where ``issues`` contains human-readable
+        warnings describing the failure conditions.
+    """
+
+    issues: List[ValidationIssue] = []
+
+    for field in REQUIRED_TOP_LEVEL_FIELDS:
+        if field not in submission:
+            issues.append(ValidationIssue(field, "missing required field"))
+
+    if issues:
+        return False, issues
+
+    metadata = submission.get("metadata", {}) or {}
+    for field in REQUIRED_METADATA_FIELDS:
+        if field not in metadata:
+            issues.append(ValidationIssue(f"metadata.{field}", "missing required field"))
+
+    category = metadata.get("category")
+    if category not in VALID_CATEGORIES:
+        issues.append(
+            ValidationIssue(
+                "metadata.category",
+                f"invalid category '{category}'. Expected one of {sorted(VALID_CATEGORIES)}",
+            )
+        )
+
+    requires_calc = bool(metadata.get("requires_calc"))
+    if requires_calc and not submission.get("calc"):
+        issues.append(ValidationIssue("calc", "required calculation explanation missing"))
+
+    citations = list(_ensure_iterable(submission.get("citations")))
+    if not citations:
+        issues.append(ValidationIssue("citations", "expected a non-empty list of citation objects"))
+        return False, issues
+
+    for idx, citation in enumerate(citations):
+        prefix = f"citations[{idx}]"
+        if not isinstance(citation, dict):
+            issues.append(ValidationIssue(prefix, "expected mapping with citation fields"))
+            continue
+
+        quote = citation.get("quote", "") or ""
+        if not quote:
+            issues.append(ValidationIssue(f"{prefix}.quote", "quote is required"))
+        elif _word_count(quote) > 30:
+            issues.append(
+                ValidationIssue(
+                    f"{prefix}.quote",
+                    f"quote has {_word_count(quote)} words (limit is 30)",
+                )
+            )
+
+        page = citation.get("page")
+        if page in (None, ""):
+            issues.append(ValidationIssue(f"{prefix}.page", "page number is required"))
+        else:
+            try:
+                page_value = int(page)
+                if page_value <= 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                issues.append(
+                    ValidationIssue(f"{prefix}.page", f"invalid page value '{page}' (positive integer required)")
+                )
+
+        url = citation.get("edgar_url", "") or ""
+        if not url:
+            issues.append(ValidationIssue(f"{prefix}.edgar_url", "EDGAR URL is required"))
+        elif not _is_sec_domain(url):
+            issues.append(
+                ValidationIssue(
+                    f"{prefix}.edgar_url",
+                    "URL must be on the sec.gov domain",
+                )
+            )
+
+        section = citation.get("section_or_note", "") or ""
+        if not section:
+            issues.append(ValidationIssue(f"{prefix}.section_or_note", "section or note is required"))
+
+    return len(issues) == 0, issues
+
+
+__all__ = ["ValidationIssue", "validate_submission"]


### PR DESCRIPTION
## Summary
- add a stage 1 programmatic validation helper to screen submissions for schema, quote length, page number, and EDGAR URL issues
- implement a lightweight stage 2 triage heuristic that highlights answers whose keywords are missing from cited quotes
- provide a minimal Dawid–Skene consensus routine with routing thresholds to flag items for SME follow-up

## Testing
- python -m compileall qa

------
https://chatgpt.com/codex/tasks/task_e_68dc4f07c078832e896cfa95901017f0